### PR TITLE
feat: Añadir información de sucursal en la tabla de horarios del personal

### DIFF
--- a/src/app/(admin)/(staff)/staff-schedules/_components/StaffSchedulesTableColumns.tsx
+++ b/src/app/(admin)/(staff)/staff-schedules/_components/StaffSchedulesTableColumns.tsx
@@ -69,6 +69,13 @@ export const columns: ColumnDef<StaffSchedule>[] = [
     cell: ({ row }) => `${row.original.staff?.name} ${row.original.staff?.lastName}`,
   },
   {
+    accessorKey: "branch.name",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Sucursal" />
+    ),
+    cell: ({ row }) => row.original.branch?.name || "Sin sucursal",
+  },
+  {
     accessorKey: "daysOfWeek",
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Días" />

--- a/src/app/(admin)/(staff)/staff-schedules/_hooks/useStaffSchedules.ts
+++ b/src/app/(admin)/(staff)/staff-schedules/_hooks/useStaffSchedules.ts
@@ -81,12 +81,19 @@ export const useStaffSchedules = (filters?: { staffId?: string; branchId?: strin
       const staffFromCache = queryClient.getQueryData<Staff[]>(["staff"]);
       const selectedStaff = staffFromCache?.find(member => member.id === variables.staffId);
 
+      // Obtener la sucursal desde la queryClient
+      const branchesFromCache = queryClient.getQueryData<any[]>(["branches"]);
+      const selectedBranch = branchesFromCache?.find(branch => branch.id === variables.branchId);
+
       // Actualizar ambas versiones de la query
       const newSchedule = {
         ...res.data,
         staff: selectedStaff ? {
           name: selectedStaff.name,
           lastName: selectedStaff.lastName
+        } : undefined,
+        branch: selectedBranch ? {
+          name: selectedBranch.name
         } : undefined
       };
 
@@ -152,7 +159,8 @@ export const useStaffSchedules = (filters?: { staffId?: string; branchId?: strin
               return {
                 ...schedule,
                 ...res.data,
-                staff: schedule.staff // Mantener datos existentes
+                staff: schedule.staff, // Mantener datos existentes del staff
+                branch: schedule.branch // Mantener datos existentes de la sucursal
               };
             }
             return schedule;
@@ -163,7 +171,6 @@ export const useStaffSchedules = (filters?: { staffId?: string; branchId?: strin
       toast.success("Horario actualizado exitosamente");
     },
     onError: (error) => {
-      console.error("💥 Error en la mutación:", error);
       if (error.message.includes("No autorizado") || error.message.includes("Unauthorized")) {
         toast.error("No tienes permisos para realizar esta acción");
       } else {

--- a/src/app/(admin)/(staff)/staff-schedules/_interfaces/staff-schedules.interface.ts
+++ b/src/app/(admin)/(staff)/staff-schedules/_interfaces/staff-schedules.interface.ts
@@ -7,6 +7,9 @@ export type StaffSchedule = components['schemas']['StaffSchedule'] & {
     name: string;
     lastName: string;
   };
+  branch?: {
+    name: string;
+  };
 };
 export type CreateStaffScheduleDto = components['schemas']['CreateStaffScheduleDto'];
 export type UpdateStaffScheduleDto = components['schemas']['UpdateStaffScheduleDto'];


### PR DESCRIPTION
- Se agregó una nueva columna para mostrar el nombre de la sucursal en StaffSchedulesTableColumns.
- Se actualizó el hook useStaffSchedules para incluir la sucursal en los datos del horario.
- Se modificó la interfaz StaffSchedule para incluir la propiedad branch.

Closes #156 