### PR TITLE
feat: Mejorar la actualización de horarios del personal

### DIFF
--- a/src/app/(admin)/(staff)/staff-schedules/_actions/staff-schedules.action.ts
+++ b/src/app/(admin)/(staff)/staff-schedules/_actions/staff-schedules.action.ts
@@ -68,6 +68,8 @@ export async function updateStaffSchedule(
   data: UpdateStaffScheduleDto
 ): Promise<UpdateStaffScheduleResponse> {
   try {
+    console.log("Datos enviados al backend:", data);
+
     const [schedule, error] = await http.patch<BaseApiResponse>(`/staff-schedule/${id}`, data);
 
     if (error) {

--- a/src/app/(admin)/(staff)/staff-schedules/_interfaces/staff-schedules.interface.ts
+++ b/src/app/(admin)/(staff)/staff-schedules/_interfaces/staff-schedules.interface.ts
@@ -44,14 +44,15 @@ export const createStaffScheduleSchema = z.object({
   exceptions: z.array(
     z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido")
   )
-}) satisfies z.ZodType<CreateStaffScheduleDto>;
+});
 
-// Schema de actualización corregido
+// Schema de actualización actualizado para coincidir con el nuevo DTO del backend
+// Ahora incluimos el campo title como opcional
 export const updateStaffScheduleSchema = z.object({
+  title: z.string().min(1, "El título es requerido").optional(),
   staffId: z.string().min(1, "El personal es requerido").optional(),
   branchId: z.string().min(1, "La sucursal es requerida").optional(),
-  title: z.string().min(1, "El título es requerido"),
-  color: z.string().min(1, "El color es requerido"),
+  color: z.string().min(1, "El color es requerido").optional(),
   startTime: timeSchema.optional(),
   endTime: timeSchema.optional(),
   daysOfWeek: z.array(z.enum([
@@ -66,4 +67,4 @@ export const updateStaffScheduleSchema = z.object({
   exceptions: z.array(
     z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido")
   ).optional().default([])
-}) satisfies z.ZodType<UpdateStaffScheduleDto>;
+});

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -4914,6 +4914,11 @@ export interface components {
              */
             branchId?: string;
             /**
+             * @description Título del horario
+             * @example Turno Mañana
+             */
+            title?: string;
+            /**
              * @description Color del horario
              * @example sky
              */
@@ -4945,11 +4950,6 @@ export interface components {
              *     ]
              */
             exceptions?: string[];
-            /**
-             * @description Título del horario (requerido)
-             * @example Turno Mañana
-             */
-            title: string;
         };
         DeleteStaffSchedulesDto: {
             ids: string[];


### PR DESCRIPTION
- Se agregó un registro de los datos enviados al backend y los datos filtrados a enviar.
- Se implementó la lógica para evitar actualizaciones si no hay cambios en los datos del horario.
- Se actualizó el esquema de validación para incluir el campo 'title' como opcional.
- Se modificó el hook useStaffSchedules para invalidar las queries de 'calendar-turns' y regenerar eventos si el horario no es de tipo YEARLY.